### PR TITLE
Update common.yaml

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -39,4 +39,7 @@ superset::pgsql_config:
 superset::python_version: 'python38'
 
 superset::db_drivers:
-  - 'psycopg2' 
+  - 'psycopg2-binary'
+  - 'cryptography==38.0.2'
+  - 'pillow'
+  - 'wtforms==2.3.3'


### PR DESCRIPTION
Solves installation errors.

 2023-03-16 13:40:57,341:INFO:superset.utils.screenshots:No PIL installation found
ALSO
Notice: /Stage[main]/Superset::Init_db/Exec[Create Admin User]/returns: Failed to create app Notice: /Stage[main]/Superset::Init_db/Exec[Create Admin User]/returns: Traceback (most recent call last):
Notice: /Stage[main]/Superset::Init_db/Exec[Create Admin User]/returns:   File "/home/superset/apache-superset/lib64/python3.8/site-packages/superset/app.py", line 37, in create_app
Notice: /Stage[main]/Superset::Init_db/Exec[Create Admin User]/returns:     app_initializer.init_app()
Notice: /Stage[main]/Superset::Init_db/Exec[Create Admin User]/returns:   File "/home/superset/apache-superset/lib64/python3.8/site-packages/superset/initialization/__init__.py", line 460, in init_app
Notice: /Stage[main]/Superset::Init_db/Exec[Create Admin User]/returns:     self.init_app_in_ctx()
Notice: /Stage[main]/Superset::Init_db/Exec[Create Admin User]/returns:   File "/home/superset/apache-superset/lib64/python3.8/site-packages/superset/initialization/__init__.py", line 410, in init_app_in_ctx
Notice: /Stage[main]/Superset::Init_db/Exec[Create Admin User]/returns:     self.configure_data_sources()
Notice: /Stage[main]/Superset::Init_db/Exec[Create Admin User]/returns:   File "/home/superset/apache-superset/lib64/python3.8/site-packages/superset/initialization/__init__.py", line 476, in configure_data_sources
Notice: /Stage[main]/Superset::Init_db/Exec[Create Admin User]/returns:     ConnectorRegistry.register_sources(module_datasource_map)
Notice: /Stage[main]/Superset::Init_db/Exec[Create Admin User]/returns:   File "/home/superset/apache-superset/lib64/python3.8/site-packages/superset/connectors/connector_registry.py", line 42, in register_sources
Notice: /Stage[main]/Superset::Init_db/Exec[Create Admin User]/returns:     module_obj = __import__(module_name, fromlist=class_names)
Notice: /Stage[main]/Superset::Init_db/Exec[Create Admin User]/returns:   File "/home/superset/apache-superset/lib64/python3.8/site-packages/superset/connectors/sqla/__init__.py", line 17, in <module>
Notice: /Stage[main]/Superset::Init_db/Exec[Create Admin User]/returns:     from . import models, views
Notice: /Stage[main]/Superset::Init_db/Exec[Create Admin User]/returns:   File "/home/superset/apache-superset/lib64/python3.8/site-packages/superset/connectors/sqla/views.py", line 28, in <module>
Notice: /Stage[main]/Superset::Init_db/Exec[Create Admin User]/returns:     from wtforms.ext.sqlalchemy.fields import QuerySelectField
Notice: /Stage[main]/Superset::Init_db/Exec[Create Admin User]/returns: ModuleNotFoundError: No module named 'wtforms.ext'
ALSO
Notice: /Stage[main]/Superset::Init_db/Exec[Initialize DB]/returns: Traceback (most recent call last):
Notice: /Stage[main]/Superset::Init_db/Exec[Initialize DB]/returns:   File "/home/superset/apache-superset/bin/superset", line 5, in <module>
Notice: /Stage[main]/Superset::Init_db/Exec[Initialize DB]/returns:     from superset.cli.main import superset
Notice: /Stage[main]/Superset::Init_db/Exec[Initialize DB]/returns:   File "/home/superset/apache-superset/lib64/python3.8/site-packages/superset/__init__.py", line 21, in <module>
Notice: /Stage[main]/Superset::Init_db/Exec[Initialize DB]/returns:     from superset.app import create_app
Notice: /Stage[main]/Superset::Init_db/Exec[Initialize DB]/returns:   File "/home/superset/apache-superset/lib64/python3.8/site-packages/superset/app.py", line 23, in <module>
Notice: /Stage[main]/Superset::Init_db/Exec[Initialize DB]/returns:     from superset.initialization import SupersetAppInitializer
Notice: /Stage[main]/Superset::Init_db/Exec[Initialize DB]/returns:   File "/home/superset/apache-superset/lib64/python3.8/site-packages/superset/initialization/__init__.py", line 33, in <module>
Notice: /Stage[main]/Superset::Init_db/Exec[Initialize DB]/returns:     from superset.extensions import (
Notice: /Stage[main]/Superset::Init_db/Exec[Initialize DB]/returns:   File "/home/superset/apache-superset/lib64/python3.8/site-packages/superset/extensions/__init__.py", line 32, in <module>
Notice: /Stage[main]/Superset::Init_db/Exec[Initialize DB]/returns:     from superset.utils.cache_manager import CacheManager
Notice: /Stage[main]/Superset::Init_db/Exec[Initialize DB]/returns:   File "/home/superset/apache-superset/lib64/python3.8/site-packages/superset/utils/cache_manager.py", line 24, in <module>
Notice: /Stage[main]/Superset::Init_db/Exec[Initialize DB]/returns:     from superset.utils.core import DatasourceType
Notice: /Stage[main]/Superset::Init_db/Exec[Initialize DB]/returns:   File "/home/superset/apache-superset/lib64/python3.8/site-packages/superset/utils/core.py", line 76, in <module>
Notice: /Stage[main]/Superset::Init_db/Exec[Initialize DB]/returns:     from cryptography.hazmat.backends.openssl.x509 import _Certificate
Notice: /Stage[main]/Superset::Init_db/Exec[Initialize DB]/returns: ModuleNotFoundError: No module named 'cryptography.hazmat.backends.openssl.x509'