### PR TITLE
Update default Superset version to 4.0.2

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -50,7 +50,7 @@ superset::pgsql_password: 'password'
 superset::pgsql_host: 'localhost'
 superset::pgsql_port: 5432
 
-superset::python_version: 'python38'
+superset::python_version: 'python39'
 superset::python_pip: 'present'
 superset::python_dev: 'present'
 superset::python_venv: 'absent'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -8,10 +8,8 @@ lookup_options:
     convert_to: "Sensitive"
 
 superset::install_dir: "/home/superset"
-superset::version: '2.1.0'
-superset::additional_python_lib:
-  - 'sqlparse==0.4.3'
-  - 'marshmallow-enum==1.5.1'
+superset::version: '4.0.2'
+superset::additional_python_lib: []
 superset::port: 8088
 superset::user: 'superset'
 superset::load_examples: false


### PR DESCRIPTION
- Update default Superset version to 4.0.2
- Update default python version to 3.9 as this is a requirement for Superset 4.0.2
- Remove additional libraries (let pip resolve Superset dependencies)