### PR TITLE
Feature update python 3.9

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,7 +8,7 @@ fixtures:
       ref: "9.2.0"
     python: 
       repo: "puppet/python"
-      ref: "7.0.0"
+      ref: "7.3.0"
     epel: 
       repo: "puppet/epel"
       ref: "4.1.0"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This Puppet module is used to do basic installation and configuration of Apache 
 Superset module installs and configures the following:
 
 * Superset dependencies
-* Python 3.8 (Optional)
+* Python (Optional)
 * Creates a Python virtual environment and installs dependent Python Libraries (including superset) within it
 * Configures Firewalld on RHEL (Optional)
 * Installs and configures a basic Postgresql Database as a Superset Back-end (Optional)
@@ -137,7 +137,7 @@ superset::gunicorn_worker_class: "tornado"
 
 The Superset module has a number of limitations:
 * It has only been tested to work on RedHat 8, Ubuntu 20.04
-* Though the Python version can be overwritten, Superset module has only been tested on Python 3.8
+* Though the Python version can be overwritten, Superset module has been tested on Python 3.9
 * Superset app configuration file limited to options currently specified in the epp template
 * It is currently only to install the current latest version of the python Superset library.  As at this release it is version 2.1.0
 * The admin parameters are limited in that any previously configured admin users will remain in Superset's DB and will need to be removed manually within the Superset 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -388,7 +388,7 @@ Data type: `String`
 
 Overide option for setting the Python version if it will be managed by this module
 
-Default value: `'python38'`
+Default value: `'python39'`
 
 ##### <a name="-superset--python_pip"></a>`python_pip`
 

--- a/data/os/Ubuntu/20.04.yaml
+++ b/data/os/Ubuntu/20.04.yaml
@@ -7,5 +7,5 @@ superset::package_dependencies:
   - 'libldap2-dev'
   - 'libpq-dev' # For Postgresql
 
-superset::python_version: '3.8'
+superset::python_version: '3.9'
 superset::python_venv: 'present'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -172,7 +172,7 @@ class superset (
   Sensitive[String]                                     $pgsql_password = Sensitive('password'),
   String                                                $pgsql_host = 'localhost',
   Integer                                               $pgsql_port = 5432,
-  String                                                $python_version = 'python38',
+  String                                                $python_version = 'python39',
   Enum['present','absent','latest']                     $python_pip = 'present',
   Enum['present','absent','latest']                     $python_dev = 'present',
   Enum['present','absent','latest']                     $python_venv = 'absent',

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppet/python",
-      "version_requirement": ">= 7.0.0 < 8.0.0"
+      "version_requirement": ">= 7.3.0 < 8.0.0"
     },
     {
       "name": "puppet/epel",

--- a/spec/classes/superset_spec.rb
+++ b/spec/classes/superset_spec.rb
@@ -40,6 +40,8 @@ describe 'superset', :class do
         it { is_expected.to contain_Python__Pip('gevent') }
         it { is_expected.to contain_Python__Pip('gunicorn') }
         it { is_expected.to contain_Python__Pip('psycopg2') }
+        it { is_expected.to contain_Python__Pip('pip') }
+        it { is_expected.to contain_Python__Pip('wheel') }
 
         it { is_expected.to contain_class('superset::config') }
 
@@ -97,6 +99,8 @@ describe 'superset', :class do
         it { is_expected.to contain_Python__Pip('gevent') }
         it { is_expected.to contain_Python__Pip('gunicorn') }
         it { is_expected.to contain_Python__Pip('psycopg2') }
+        it { is_expected.to contain_Python__Pip('pip') }
+        it { is_expected.to contain_Python__Pip('wheel') }
 
         it { is_expected.to contain_class('superset::config') }
 
@@ -160,6 +164,8 @@ describe 'superset', :class do
         it { is_expected.to contain_Python__Pip('gevent') }
         it { is_expected.to contain_Python__Pip('gunicorn') }
         it { is_expected.to contain_Python__Pip('psycopg2') }
+        it { is_expected.to contain_Python__Pip('pip') }
+        it { is_expected.to contain_Python__Pip('wheel') }
 
         it { is_expected.to contain_class('superset::config') }
 


### PR DESCRIPTION
- Update missed references to Python 3.8 to Python 3.9
- Update dependency to puppet-python module to 7.3.0 as the virtual environment was not being updated by Hiera data changes in version 7.0.0